### PR TITLE
dev: Setup git commit message template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+
+# Git commit message
+All commit's messages must adhere to the following rules. 
+
+ - [Commit message rules][]
+ - [Commit message template][]
+ - [Message example][]
+ - [Tips][]
+
+If you want to read more and better understand these rules, check out this [article][].
+
+[Commit message rules]: #Commit_message_rules
+[Commit message template]: #Commit_message_template
+[Message example]: #Message_template
+[Tips]: #Tips
+[article]: https://chris.beams.io/posts/git-commit/
+
+
+## Commit message rules
+The main rules to follow in writing a commit message are:
+ - Separate subject from body with a blank line
+ - Limit the subject line to 50 characters
+ - Capitalize the subject line
+ - Do not end the subject line with a period
+ - Use the imperative mood in the subject line
+ - Wrap the body at 72 characters
+ - Use the body to explain what and why vs. how
+
+The body of the commit is organized in three sections: the commit's __subject__, 
+the commit's __description__ and its __additional information__. 
+
+The subject is always required, wile the description and additional info sections are optional.
+
+
+## Commit message template 
+A handy [template][] is provided to help you along the way on writing your commit messages. 
+In order for git to use this template, just run the script 'set-git-commit-template' in the 
+script section of the [package.json][], or run the following git command 
+from the project root folder: 
+
+		git config commit.template script/git/commit_template 
+
+[template]: /scripts/git/commit_template
+[package.json]: /package.json
+
+
+## Message example
+The following is a simple example of a commit message following the abovementioned rules:
+
+		Summarize changes in around 50 characters or less
+
+		More detailed explanatory text, if necessary. Wrap it to about 72
+		characters or so. In some contexts, the first line is treated as the
+		subject of the commit and the rest of the text as the body. The
+		blank line separating the summary from the body is critical (unless
+		you omit the body entirely); various tools like log, shortlog
+		and rebase can get confused if you run the two together.
+
+		Explain the problem that this commit is solving. Focus on why you
+		are making this change as opposed to how (the code explains that).
+		Are there side effects or other unintuitive consequences of this
+		change? Here's the place to explain them.
+
+		Further paragraphs come after blank lines.
+
+		- Bullet points are okay, too
+
+		- Typically a hyphen or asterisk is used for the bullet, preceded
+		by a single space, with blank lines in between, but conventions
+		vary here
+
+		If you use an issue tracker, put references to them at the bottom,
+		like this:
+
+		Resolves: #123
+		See also: #456, #789
+
+
+## Tips
+ - Set up git with the text editor of your choice
+ - Configure your editor to automatically wrap the text to 72 chars
+ - Never use the `-m \<msg\>` / `--message=\<msg\>` flag to `git commit`
+ - Favor the git CLI to GUIs and IDE integrations

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint:ci": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "prettier": "prettier --write \"**/src/**/*.@(js|jsx|ts|tsx)\"",
     "prettier:ci": "prettier --check \"**/src/**/*.@(js|jsx|ts|tsx)\"",
-    "link:core": "rimraf docs/node_modules/@common-components && node scripts/link.js"
+	"link:core": "rimraf docs/node_modules/@common-components && node scripts/link.js",
+	"set-git-commit-template": "node ./scripts/git/set-commit-template.js"
   },
   "dependencies": {
     "typescript": "4.0.3",

--- a/scripts/git/commit_template
+++ b/scripts/git/commit_template
@@ -1,0 +1,43 @@
+# <type>: (If applied, this commit will...) <subject> (Max 50 char)
+# |<----  Using a Maximum Of 50 Characters  ---->|
+
+
+# Explain why this change is being made
+# |<----   Try To Limit Each Line to a Maximum Of 72 Characters   ---->|
+
+
+# Provide links or keys to any relevant tickets, articles or other resources
+# Example
+#    Resolves: Github issue #23
+#    See also: Github issue #25, #26
+
+
+# --- COMMIT END ---
+#
+# Type can be
+#    feature  (new feature)
+#    fix      (bug fix)
+#    refactor (refactoring production code)
+#    dev      (setup, automations, contributing updates, etc)
+#    docs     (changes to documentation)
+#    test     (adding or refactoring tests)
+#    wip      (work in progress commit to be squashed -- do not push!)**
+#
+# --------------------
+#
+# Remember to
+#   - Separate subject from body with a blank line
+#   - Limit the subject line to 50 characters
+#   - Capitalize the subject line
+#   - Do not end the subject line with a period
+#   - Use the imperative mood in the subject line
+#   - Wrap the body at 72 characters
+#   - Use the body to explain what and why vs. how
+#   - Can use multiple lines with "-" for bullet points in body
+# 
+# --------------------
+#
+# For more information check out https://chris.beams.io/posts/git-commit/
+#
+#
+#

--- a/scripts/git/set-commit-template.js
+++ b/scripts/git/set-commit-template.js
@@ -1,0 +1,3 @@
+const {execSync} = require('child_process')
+
+execSync('git config commit.template scripts/git/commit_template')


### PR DESCRIPTION
This changes introduce a commit message's template, in order to make
easier the following of the commit message's style rules.

A script has been provided to help with the git setup.